### PR TITLE
fix: Bump timeout for validate bag checksum lambda

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -3,7 +3,7 @@ resource "aws_lambda_function" "vb_bagit_checksum_validation" {
   package_type  = "Image"
   function_name = local.lambda_name_bag_validation
   role          = aws_iam_role.validate_bagit_lambda_invoke_role.arn
-  timeout       = 30
+  timeout       = 60
 
   environment {
     variables = {


### PR DESCRIPTION
We saw a timeout in v2 earlier today for a bag with multiple images. This should give the lambda a little more time to process in these edge cases.