### PR TITLE
Bump files validation lambda timeout

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -3,7 +3,7 @@ resource "aws_lambda_function" "vb_bagit_checksum_validation" {
   package_type  = "Image"
   function_name = local.lambda_name_bag_validation
   role          = aws_iam_role.validate_bagit_lambda_invoke_role.arn
-  timeout       = 30
+  timeout       = 60
 
   environment {
     variables = {


### PR DESCRIPTION
We observed a timeout in the `vb-bag-files-validation` lambda while testing in integration for a file with numerous images. This bumps the timeout to allow enough time to deal with these sorts of edge cases.