### PR TITLE
Change logic to _not validate_ only for` STANDARD` consignment type r…

### DIFF
--- a/templates/step-function-definition.json.tftpl
+++ b/templates/step-function-definition.json.tftpl
@@ -7,11 +7,11 @@
       "Choices": [
         {
           "Variable": "$.parameters.consignmentType",
-          "StringEquals": "COURT_DOCUMENT",
-          "Next": "Files Checksum Validation"
+          "StringEquals": "STANDARD",
+          "Next": "Validation Not Required"
         }
       ],
-      "Default": "Validation Not Required"
+      "Default": "Files Checksum Validation"
     },
     "Files Checksum Validation": {
       "Type": "Task",


### PR DESCRIPTION
…ather than _validate_ only for `COURT_DOCUMENT` consignment type