### PR TITLE
TDR-3696 Remove common_tre_slack_alerts_topic_arn

### DIFF
--- a/sfn.tf
+++ b/sfn.tf
@@ -5,7 +5,6 @@ resource "aws_sfn_state_machine" "validate_bagit" {
     arn_lambda_vb_bagit_checksum_validation = aws_lambda_function.vb_bagit_checksum_validation.arn
     arn_lambda_vb_files_checksum_validation = aws_lambda_function.vb_files_checksum_validation.arn
     arn_sns_topic_validate_bagit_out        = var.notification_topic_arn
-    arn_sns_topic_tre_slack_alerts          = var.common_tre_slack_alerts_topic_arn
   })
   logging_configuration {
     log_destination        = "${aws_cloudwatch_log_group.validate_bagit.arn}:*"

--- a/templates/step-function-definition.json.tftpl
+++ b/templates/step-function-definition.json.tftpl
@@ -90,13 +90,22 @@
       "Type": "Task",
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
-        "TopicArn": "${arn_sns_topic_tre_slack_alerts}",
+        "TopicArn": "${arn_sns_topic_validate_bagit_out}",
         "Message": {
-          "Execution.$": "$$.Execution.Name",
-          "StateMachine.$": "$$.StateMachine.Name",
-          "Status": "error",
-          "ErrorMessage.$": "$.properties.function",
-          "Event": "Invalid event-name (Files)"
+          "properties": {
+            "messageType": "uk.gov.nationalarchives.tre.messages.treerror.TreError",
+            "function": "tre-validate-bagit",
+            "producer": "TRE",
+            "executionId.$": "$$.Execution.Name",
+            "parentExecutionId": null,
+            "timestamp.$": "$$.State.EnteredTime"
+          },
+          "parameters": {
+            "status": "TRE_ERROR",
+            "originator": "TDR",
+            "reference.$": "$.parameters.reference",
+            "errors.$": "$.properties.function"
+          }
         }
       },
       "Next": "Files Checksum Unhandled Event"
@@ -142,13 +151,22 @@
       "Type": "Task",
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
-        "TopicArn": "${arn_sns_topic_tre_slack_alerts}",
+        "TopicArn": "${arn_sns_topic_validate_bagit_out}",
         "Message": {
-          "Execution.$": "$$.Execution.Name",
-          "StateMachine.$": "$$.StateMachine.Name",
-          "Status": "error",
-          "ErrorMessage.$": "$.properties.function",
-          "Event": "Invalid event-name (SNS Notification Topic)"
+          "properties": {
+            "messageType": "uk.gov.nationalarchives.tre.messages.treerror.TreError",
+            "function": "tre-validate-bagit",
+            "producer": "TRE",
+            "executionId.$": "$$.Execution.Name",
+            "parentExecutionId": null,
+            "timestamp.$": "$$.State.EnteredTime"
+          },
+          "parameters": {
+            "status": "TRE_ERROR",
+            "originator": "TDR",
+            "reference.$": "$.parameters.reference",
+            "errors.$": "$.properties.function"
+          }
         }
       },
       "Next": "Unhandled Event"

--- a/variables.tf
+++ b/variables.tf
@@ -28,11 +28,6 @@ variable "vb_image_versions" {
   })
 }
 
-variable "common_tre_slack_alerts_topic_arn" {
-  description = "ARN of the Common TRE Slack Alerts SNS Topic"
-  type        = string
-}
-
 variable "notification_topic_arn" {
   description = "The notification SNS topic ARN"
   type        = string


### PR DESCRIPTION
Redirect step function old error messages to eventbus

This currently causes the tests to fail.